### PR TITLE
Update ci to build test and package maven project

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -16,7 +16,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+      - name: Restore Maven cache
+        uses: skjolber/maven-cache-github-action@v1
+        with:
+          step: restore
       - run: mvn clean compile
+      - name: Save Maven cache
+        uses: skjolber/maven-cache-github-action@v1
+        with:
+          step: save
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -36,6 +44,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+      - name: Restore Maven cache
+        uses: skjolber/maven-cache-github-action@v1
+        with:
+          step: restore
       - run: mvn test
   Package:
     runs-on: ubuntu-latest
@@ -50,6 +62,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+      - name: Restore Maven cache
+        uses: skjolber/maven-cache-github-action@v1
+        with:
+          step: restore
       - run: mvn package
       - run: cp target/backend-0.0.1-SNAPSHOT.jar AMT-backend.jar
       - name: Upload package artifacts

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          echo "I should be building the project here, but I do not know how \
-          to build it yet."
-          date > build-datetime.txt
-          echo "I stored the build date time in a text file."
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - run: mvn clean compile
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: build-datetime
-          path: build-datetime.txt
+          name: build-result
+          path: target
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -31,12 +31,12 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: build-datetime
-      - run: |
-          echo "I should be running the project unit tests here. But they have \
-          not been implemented yet. Note that I should not build them since \
-          they should have already been built in the “build” stage."
-          echo "Using build artifacts from $(cat build-datetime.txt)."
+          name: build-result
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - run: mvn test
   Package:
     runs-on: ubuntu-latest
     needs: Build
@@ -45,19 +45,18 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: build-datetime
-      - run: |
-          echo "I would be packaging the application in a format suitable for \
-          deployment but this is not yet implemented. Note that I should not \
-          build them since they should have already been built in the “build” \
-          stage."
-          echo "Using build artifacts from $(cat build-datetime.txt)."
-          cp build-datetime.txt package-artifact.txt
+          name: build-result
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - run: mvn package
+      - run: cp target/backend-0.0.1-SNAPSHOT.jar AMT-backend.jar
       - name: Upload package artifacts
         uses: actions/upload-artifact@v2
         with:
           name: package-artifact
-          path: package-artifact.txt
+          path: AMT-backend.jar
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-latest
@@ -66,9 +65,10 @@ jobs:
       - name: Download package artifacts
         uses: actions/download-artifact@v2
         with:
-          path: package-artifact
+          path: AMT-backend.jar
       - run: |
           echo "I would be running integration tests on the release package \
           but this is not yet implemented. Note that I should not require \
           access to the code, but all my inputs should be artifacts."
-          echo "Using package artifact $(cat package-artifact.txt)."
+          echo "Using package artifact:"
+          stat AMT-backend.jar


### PR DESCRIPTION
## This MR contains the following changes:

- Update CI on-push workflow to build, run unit tests and produce a release jar file.
- Add maven dependency caching.

## Potentially unadressed issues:

The CI does not handle yet integration tests. Integration requirements are expected to change fast over the next couple of days (e.g. add postgres); hence it would be more efficient to implement so by then.