### PR TITLE
Add simple health check endpoint returning 200

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/src/main/java/ch/heigvd/amt/backend/routes/HealthCheck.java
+++ b/src/main/java/ch/heigvd/amt/backend/routes/HealthCheck.java
@@ -1,0 +1,12 @@
+package ch.heigvd.amt.backend.routes;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheck {
+  @GetMapping("/health")
+  public String health() {
+    return "OK";
+  }
+}


### PR DESCRIPTION
This commit adds a simple endpoint returning the string "OK" under "/health".
This is both to provide procedure to implement healthcheck where required and so that the context loaded by string does not automatically exit, but instead creates a web server.

(The code on this MR has been validated by the linter on #5).