### PR TITLE
Have user management webapp do real calls to the user auth service

### DIFF
--- a/infra/playbooks/group_vars/vagrant-testing.yml
+++ b/infra/playbooks/group_vars/vagrant-testing.yml
@@ -7,4 +7,3 @@ ansible_ssh_common_args: >-
 
 # There's no way to reach this service on a local deployment.
 ochap_usermgmt_auth_service_url: http://unexistent
-ochap_usermgmt_auth_service_admin_jwt: invalid

--- a/infra/roles/ochap-apps/README.md
+++ b/infra/roles/ochap-apps/README.md
@@ -9,14 +9,13 @@ Deploys the ochap WARs and configuration files.
 
 ## Role variables
 
-Variable                                | Description                                              | Type     |
---------                                | -----------                                              | ----     |
-`ochap_backend_db_name`                 | Name of the database used for ochap-backend              | String   |
-`ochap_backend_db_user`                 | Username of the database user for ochap-backend          | String   |
-`ochap_backend_db_pass`                 | Password of the database user for ochap-backend          | String   |
-`ochap_usermgmt_auth_service_url`       | Base URL where the authentication service may be reached | String   |
-`ochap_usermgmt_auth_service_admin_jwt` | JWT token with admin privileges in the auth service      | String   |
-`wars_to_deploy`                        | Path to web application archives to deploy               | [String] |
+Variable                          | Description                                              | Type     |
+--------                          | -----------                                              | ----     |
+`ochap_backend_db_name`           | Name of the database used for ochap-backend              | String   |
+`ochap_backend_db_user`           | Username of the database user for ochap-backend          | String   |
+`ochap_backend_db_pass`           | Password of the database user for ochap-backend          | String   |
+`ochap_usermgmt_auth_service_url` | Base URL where the authentication service may be reached | String   |
+`wars_to_deploy`                  | Path to web application archives to deploy               | [String] |
 
 ### Variables with acceptable default values
 

--- a/infra/roles/ochap-apps/templates/ochap_usermgmt.application.properties
+++ b/infra/roles/ochap-apps/templates/ochap_usermgmt.application.properties
@@ -1,2 +1,1 @@
 authServiceBaseUrl={{ ochap_usermgmt_auth_service_url }}
-authServiceAdminJwt={{ ochap_usermgmt_auth_service_admin_jwt }}

--- a/ochap-backend/src/main/resources/templates/fragments/header.html
+++ b/ochap-backend/src/main/resources/templates/fragments/header.html
@@ -5,40 +5,9 @@
 </head>
 <body>
     <header>
-    <div class="head_top">
-        <div class="header">
-
-            <div class="container-fluid">
-
-                <div class="row">
-                    <div class="col-lg-3 logo_section">
-                        <div class="full">
-                            <div class="center-desk">
-                                <div class="logo">
-                                    <a href="/"><img src="images/logo.png" alt="#"></a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-lg-9">
-                        <div class="right_header_info">
-                            <ul>
-                                <li class="menu_iconb">
-                                    <a href="#">Log in <img style="margin-right: 15px;" src="icon/5.png" alt="#" /> </a>
-                                </li>
-                                <li class="menu_iconb">
-                                    <a href="#">Signup<img style="margin-left: 15px;" src="icon/6.png" alt="#" /></a>
-                                </li>
-                                <li class="tytyu">
-                                    <a href="/shopping-cart"> <img style="margin-right: 15px;" src="icon/2.png" alt="#" /></a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
+        <div class="head_top">
+          <div th:replace="fragments/inner-header-div :: div"></div>
         </div>
-    </div>
     </header>
 </body>
 </html>

--- a/ochap-backend/src/main/resources/templates/fragments/inner-header-div.html
+++ b/ochap-backend/src/main/resources/templates/fragments/inner-header-div.html
@@ -20,10 +20,10 @@
                     <div class="right_header_info">
                         <ul>
                             <li class="menu_iconb">
-                                <a th:href="#">Log in <img style="margin-right: 15px;" src="icon/5.png" alt="#" /> </a>
+                                <a th:href="@{/users/login(callback=${#httpServletRequest.requestURI})}">Log in <img style="margin-right: 15px;" src="icon/5.png" alt="#" /> </a>
                             </li>
                             <li class="menu_iconb">
-                                <a th:href="#">Signup<img style="margin-left: 15px;" src="icon/6.png" alt="#" /></a>
+                                <a th:href="@{/users/register(callback=${#httpServletRequest.requestURI})}">Signup<img style="margin-left: 15px;" src="icon/6.png" alt="#" /></a>
                             </li>
                             <li class="tytyu">
                                 <a href="/shopping-cart"> <img style="margin-right: 15px;" src="icon/2.png" alt="#" /></a>

--- a/ochap-backend/src/main/resources/templates/fragments/inner-header-div.html
+++ b/ochap-backend/src/main/resources/templates/fragments/inner-header-div.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+    <div class="header">
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-lg-3 logo_section">
+                    <div class="full">
+                        <div class="center-desk">
+                            <div class="logo">
+                                <a href="/"><img src="images/logo.png" alt="#"></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-lg-9">
+                    <div class="right_header_info">
+                        <ul>
+                            <li class="menu_iconb">
+                                <a th:href="#">Log in <img style="margin-right: 15px;" src="icon/5.png" alt="#" /> </a>
+                            </li>
+                            <li class="menu_iconb">
+                                <a th:href="#">Signup<img style="margin-left: 15px;" src="icon/6.png" alt="#" /></a>
+                            </li>
+                            <li class="tytyu">
+                                <a href="/shopping-cart"> <img style="margin-right: 15px;" src="icon/2.png" alt="#" /></a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/ochap-backend/src/main/resources/templates/index.html
+++ b/ochap-backend/src/main/resources/templates/index.html
@@ -74,44 +74,8 @@
         <div id="content">
             <!-- header -->
             <header>
-                <!-- header inner -->
                 <div class="head_top">
-                    <div class="header">
-
-                        <div class="container-fluid">
-
-                            <div class="row">
-                                <div class="col-lg-3 logo_section">
-                                    <div class="full">
-                                        <div class="center-desk">
-                                            <div class="logo">
-                                                <a href="/"><img src="images/logo.png" alt="#"></a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-9">
-                                    <div class="right_header_info">
-                                        <ul>
-                                            <li class="menu_iconb">
-                                                <a href="#">Log in <img style="margin-right: 15px;" src="icon/5.png" alt="#" /> </a>
-                                            </li>
-                                            <li class="menu_iconb">
-                                                <a href="#">Signup<img style="margin-left: 15px;" src="icon/6.png" alt="#" /></a>
-                                            </li>
-                                            <li class="tytyu">
-                                                <a href="#"> <img style="margin-right: 15px;" src="icon/2.png" alt="#" /></a>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- end header inner -->
-
-                    <!-- end header -->
+                    <div th:replace="fragments/inner-header-div :: div"></div>
                     <section class="slider_section">
                         <div class="banner_main">
                             <div class="container-fluid padding3">

--- a/ochap-backend/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/ochap-backend/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+      http://www.jboss.com/xml/ns/javaee
+      http://www.jboss.org/j2ee/schema/jboss-web_5_1.xsd">
+    <context-root>/</context-root>
+</jboss-web>

--- a/ochap-user-management/README.md
+++ b/ochap-user-management/README.md
@@ -1,0 +1,33 @@
+# User account creation and authentication
+
+This **application** consumes an external service for user management,
+henceforth _the authentication service_.
+This application serves the pages for a user to create an account or login.
+
+## Deployment
+
+The application is expected to run on a [Wildfly][] application server.
+
+[Wildfly]: https://www.wildfly.org/
+
+When run under [Wildfly][], the application expects the configuration module
+`ch.heigvd.amt.ochap_usermgmt.configuration` to be available; moreover the
+resource path is expected to contain an `application.properties` file with the
+following variables:
+
+Variable              | Description                             |
+--------              | -----------                             |
+`authServiceBaseUrl`  | Base URL of the authentication service  |
+
+## Testing
+
+Tests may be run using `mvn test` as expected.
+Mind that some tests require real credentials to the external authentication
+service and are thus skipped by default.
+If this credentials are available, these test can be run using the following
+command:
+
+```console
+$ mvn test -Dtest='AmtAuthServiceTests' \
+  -DauthServiceBaseUrl=http://localhost:22345
+```

--- a/ochap-user-management/pom.xml
+++ b/ochap-user-management/pom.xml
@@ -27,9 +27,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
-		<dependency> 
-			<groupId>org.springframework.boot</groupId> 
-			<artifactId>spring-boot-starter-validation</artifactId> 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -60,6 +64,18 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>4.0.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>4.0.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/OchapUserManagementApplication.java
+++ b/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/OchapUserManagementApplication.java
@@ -1,9 +1,16 @@
 package ch.heigvd.amt.ochap.usermgmt;
 
+import java.net.URL;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
 @SpringBootApplication
 public class OchapUserManagementApplication extends SpringBootServletInitializer {
@@ -14,5 +21,15 @@ public class OchapUserManagementApplication extends SpringBootServletInitializer
 
   public static void main(String[] args) {
     SpringApplication.run(OchapUserManagementApplication.class, args);
+  }
+
+  @Bean("AuthServiceWebClient")
+  public WebClient authServiceWebClient(@Value("${authServiceBaseUrl}") String baseUrl)
+      throws Exception {
+    URL parsed = new URL(baseUrl); // Validates the specified URL is valid.
+    if (!StringUtils.hasLength(parsed.getProtocol()) || !StringUtils.hasLength(parsed.getHost()))
+      throw new Exception(
+          "The specified base URL for the authentication service is invalid: " + parsed.toString());
+    return WebClient.builder().uriBuilderFactory(new DefaultUriBuilderFactory(baseUrl)).build();
   }
 }

--- a/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/Routes.java
+++ b/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/Routes.java
@@ -35,6 +35,15 @@ public class Routes {
   @Autowired
   AmtAuthService authServer;
 
+  // Send strayed users back to the homepage.
+  @GetMapping(value = "/")
+  public void method(@RequestParam Map<String, String> queryParams,
+      HttpServletResponse httpServletResponse) {
+    String backUrl = queryParams.getOrDefault("back", "/");
+    httpServletResponse.setHeader("Location", backUrl);
+    httpServletResponse.setStatus(302);
+  }
+
   @GetMapping("/test-oups-page")
   public String oups(Model model) {
     model.addAttribute("problemTitle", "Test oups page.");

--- a/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/Routes.java
+++ b/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/Routes.java
@@ -1,5 +1,6 @@
 package ch.heigvd.amt.ochap.usermgmt;
 
+import java.time.Duration;
 import java.util.Map;
 
 import javax.servlet.http.Cookie;
@@ -7,6 +8,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,11 +18,19 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.View;
 
+import ch.heigvd.amt.ochap.usermgmt.data.AccountInfoDTO;
 import ch.heigvd.amt.ochap.usermgmt.data.LoginDTO;
 import ch.heigvd.amt.ochap.usermgmt.data.RegisterDTO;
+import ch.heigvd.amt.ochap.usermgmt.data.TokenDTO;
+import ch.heigvd.amt.ochap.usermgmt.service.AmtAuthService;
+import ch.heigvd.amt.ochap.usermgmt.service.AmtAuthService.IncorrectCredentialsException;
+import ch.heigvd.amt.ochap.usermgmt.service.AmtAuthService.UsernameAlreadyExistsException;
 
 @Controller
 public class Routes {
+  @Autowired
+  AmtAuthService authServer;
+
   @GetMapping("/test-oups-page")
   public String oups(Model model) {
     model.addAttribute("problemTitle", "Test oups page.");
@@ -35,6 +45,13 @@ public class Routes {
     return "login";
   }
 
+  private String tryLoginAndMakeAuth(String username, String password)
+      throws IncorrectCredentialsException {
+    TokenDTO upstreamLogin =
+        authServer.login(username, password).timeout(Duration.ofSeconds(10)).block();
+    return "Bearer " + upstreamLogin.getToken();
+  }
+
   @PostMapping(path = "/login")
   public String loginPerform(@RequestParam Map<String, String> queryParams,
       @Valid LoginDTO loginDTO, BindingResult bindingResult, Model model,
@@ -45,9 +62,15 @@ public class Routes {
       return "login";
     }
 
-    request.setAttribute(View.RESPONSE_STATUS_ATTRIBUTE, HttpStatus.SEE_OTHER);
-    response.addCookie(new Cookie("Authorization", "invalid-login-not-implemented"));
-    return "redirect:" + callbackUrl;
+    try {
+      String auth = tryLoginAndMakeAuth(loginDTO.getUsername(), loginDTO.getPassword());
+      request.setAttribute(View.RESPONSE_STATUS_ATTRIBUTE, HttpStatus.SEE_OTHER);
+      response.addCookie(new Cookie("Authorization", auth));
+      return "redirect:" + callbackUrl;
+    } catch (IncorrectCredentialsException e) {
+      // Let the user know the specified credentials were not valid.
+      throw new RuntimeException("Not implemented.");
+    }
   }
 
   @GetMapping("/register")
@@ -66,8 +89,26 @@ public class Routes {
       return "register";
     }
 
-    request.setAttribute(View.RESPONSE_STATUS_ATTRIBUTE, HttpStatus.SEE_OTHER);
-    response.addCookie(new Cookie("Authorization", "invalid-register-not-implemented"));
-    return "redirect:" + callbackUrl;
+    String username = registerDTO.getUsername();
+    String password = registerDTO.getPassword();
+
+    try {
+      AccountInfoDTO registration =
+          authServer.register(username, password).timeout(Duration.ofSeconds(10)).block();
+    } catch (UsernameAlreadyExistsException e) {
+      // Let the view know the chosen username is not available.
+      // Perhaphs they would like to log in.
+      throw new RuntimeException("Not implemented.");
+    }
+
+    try {
+      String auth = tryLoginAndMakeAuth(username, password);
+      request.setAttribute(View.RESPONSE_STATUS_ATTRIBUTE, HttpStatus.SEE_OTHER);
+      response.addCookie(new Cookie("Authorization", auth));
+      return "redirect:" + callbackUrl;
+    } catch (IncorrectCredentialsException e) {
+      // This should not happen, show a nice message...
+      throw new RuntimeException("Not implemented.");
+    }
   }
 }

--- a/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/data/AccountInfoDTO.java
+++ b/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/data/AccountInfoDTO.java
@@ -1,0 +1,20 @@
+package ch.heigvd.amt.ochap.usermgmt.data;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class AccountInfoDTO {
+  @NotNull
+  Long id;
+
+  @NotEmpty
+  String username;
+
+  @NotEmpty
+  String role;
+}

--- a/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/data/TokenDTO.java
+++ b/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/data/TokenDTO.java
@@ -1,0 +1,19 @@
+package ch.heigvd.amt.ochap.usermgmt.data;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Data
+@NoArgsConstructor
+public class TokenDTO {
+  @NotEmpty
+  String token;
+
+  @NotNull
+  AccountInfoDTO account;
+}

--- a/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/data/TokenDTO.java
+++ b/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/data/TokenDTO.java
@@ -3,8 +3,8 @@ package ch.heigvd.amt.ochap.usermgmt.data;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
-import lombok.Data;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @AllArgsConstructor

--- a/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/service/AmtAuthService.java
+++ b/ochap-user-management/src/main/java/ch/heigvd/amt/ochap/usermgmt/service/AmtAuthService.java
@@ -1,0 +1,62 @@
+package ch.heigvd.amt.ochap.usermgmt.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import ch.heigvd.amt.ochap.usermgmt.data.AccountInfoDTO;
+import ch.heigvd.amt.ochap.usermgmt.data.LoginDTO;
+import ch.heigvd.amt.ochap.usermgmt.data.RegisterDTO;
+import ch.heigvd.amt.ochap.usermgmt.data.TokenDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import reactor.core.publisher.Mono;
+
+@Component
+public class AmtAuthService {
+  public static class IncorrectCredentialsException extends Exception {
+  }
+
+  public static class UsernameAlreadyExistsException extends Exception {
+  }
+
+  @Autowired
+  @Qualifier("AuthServiceWebClient")
+  WebClient httpClient;
+
+  @Data
+  @AllArgsConstructor
+  private static class AuthLoginCommand {
+    String username;
+    String password;
+  }
+
+  @Data
+  @AllArgsConstructor
+  private static class AccountRegisterCommand {
+    String username;
+    String password;
+  }
+
+  public Mono<TokenDTO> login(String username, String password)
+      throws IncorrectCredentialsException {
+    var cmd = new AuthLoginCommand(username, password);
+    return httpClient.post().uri("/auth/login").contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON).body(Mono.just(cmd), AuthLoginCommand.class).retrieve()
+        .onStatus(HttpStatus.FORBIDDEN::equals, r -> Mono.error(IncorrectCredentialsException::new))
+        .bodyToMono(TokenDTO.class);
+  }
+
+  public Mono<AccountInfoDTO> register(String username, String password)
+      throws UsernameAlreadyExistsException {
+    var cmd = new AccountRegisterCommand(username, password);
+    return httpClient.post().uri("/accounts/register").contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON).body(Mono.just(cmd), AccountRegisterCommand.class)
+        .retrieve()
+        .onStatus(HttpStatus.CONFLICT::equals, r -> Mono.error(UsernameAlreadyExistsException::new))
+        .bodyToMono(AccountInfoDTO.class);
+  }
+}

--- a/ochap-user-management/src/main/resources/templates/login.html
+++ b/ochap-user-management/src/main/resources/templates/login.html
@@ -15,6 +15,8 @@
         accept-charset="utf-8"
         th:action="@{login(callback=${callbackUrl})}" th:object="${loginDTO}"
         method="POST">
+        <div class="alert alert-warning"
+         th:each="err : ${#fields.globalErrors()}" th:text="${err}"/>
 
         <div class="form-aligned-fields">
           <label for="username">Username</label>

--- a/ochap-user-management/src/main/resources/templates/login.html
+++ b/ochap-user-management/src/main/resources/templates/login.html
@@ -48,6 +48,8 @@
         accept-charset="utf-8"
         th:action="@{*{cancelUrl}?: '/'}"
         method="GET">
+        <input name="back" type="hidden" th:value="${#request.getParameter('callback')}">
+      </form>
     </div>
   </main>
 </body>

--- a/ochap-user-management/src/main/resources/templates/register.html
+++ b/ochap-user-management/src/main/resources/templates/register.html
@@ -15,6 +15,8 @@
         accept-charset="utf-8"
         th:action="@{register(callback=${callbackUrl})}" th:object="${registerDTO}"
         method="POST">
+        <div class="alert alert-warning"
+         th:each="err : ${#fields.globalErrors()}" th:text="${err}"/>
 
         <div class="form-aligned-fields">
           <label for="username">Username</label>

--- a/ochap-user-management/src/main/resources/templates/register.html
+++ b/ochap-user-management/src/main/resources/templates/register.html
@@ -48,6 +48,8 @@
         accept-charset="utf-8"
         th:action="@{*{cancelUrl}?: '/'}"
         method="GET">
+        <input name="back" type="hidden" th:value="${#request.getParameter('callback')}">
+      </form>
     </div>
   </main>
 </body>

--- a/ochap-user-management/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/ochap-user-management/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+  <deployment>
+    <dependencies>
+      <module name="ch.heigvd.amt.ochap_usermgmt.configuration"/>
+    </dependencies>
+  </deployment>
+</jboss-deployment-structure>

--- a/ochap-user-management/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/ochap-user-management/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="
+      http://www.jboss.com/xml/ns/javaee
+      http://www.jboss.org/j2ee/schema/jboss-web_5_1.xsd">
+    <context-root>users</context-root>
+</jboss-web>

--- a/ochap-user-management/src/test/java/ch/heigvd/amt/ochap/usermgmt/AmtAuthServiceTests.java
+++ b/ochap-user-management/src/test/java/ch/heigvd/amt/ochap/usermgmt/AmtAuthServiceTests.java
@@ -1,0 +1,39 @@
+package ch.heigvd.amt.ochap.usermgmt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import ch.heigvd.amt.ochap.usermgmt.data.AccountInfoDTO;
+import ch.heigvd.amt.ochap.usermgmt.data.TokenDTO;
+import ch.heigvd.amt.ochap.usermgmt.service.AmtAuthService;
+
+@EnabledIfSystemProperty(named = "authServiceBaseUrl", matches = "\\S+",
+    disabledReason = "Test cannot be run if Auth Service is not known.")
+@SpringBootTest
+public class AmtAuthServiceTests {
+  @Autowired
+  private AmtAuthService amtAuthServer;
+
+  @Test
+  void createdUsersCanLogin() throws Exception {
+    var tsFormat = DateTimeFormatter.ofPattern("yyMMdd-HHmmssSS");
+    var username = "test-ochap-" + LocalDateTime.now().format(tsFormat);
+    var password = "OChap$" + UUID.randomUUID().toString();
+
+    AccountInfoDTO regResult = amtAuthServer.register(username, password).block();
+    assertNotNull(regResult.getId());
+    assertEquals(username, regResult.getUsername());
+
+    TokenDTO loginResult = amtAuthServer.login(username, password).block();
+    assertNotNull(loginResult.getToken());
+    assertEquals(regResult, loginResult.getAccount());
+  }
+}

--- a/ochap-user-management/src/test/java/ch/heigvd/amt/ochap/usermgmt/AuthServiceWebClientTest.java
+++ b/ochap-user-management/src/test/java/ch/heigvd/amt/ochap/usermgmt/AuthServiceWebClientTest.java
@@ -17,7 +17,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 
-@SpringBootTest(properties = {"spring.main.lazy-initialization=true"})
+@SpringBootTest
 @ContextConfiguration(initializers = AuthServiceWebClientTest.ContextInitializer.class)
 public class AuthServiceWebClientTest {
   static final MockWebServer mockWebServer = new MockWebServer();

--- a/ochap-user-management/src/test/java/ch/heigvd/amt/ochap/usermgmt/AuthServiceWebClientTest.java
+++ b/ochap-user-management/src/test/java/ch/heigvd/amt/ochap/usermgmt/AuthServiceWebClientTest.java
@@ -1,0 +1,58 @@
+package ch.heigvd.amt.ochap.usermgmt;
+
+import static org.junit.Assert.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+@SpringBootTest(properties = {"spring.main.lazy-initialization=true"})
+@ContextConfiguration(initializers = AuthServiceWebClientTest.ContextInitializer.class)
+public class AuthServiceWebClientTest {
+  static final MockWebServer mockWebServer = new MockWebServer();
+  static final String authMountPoint = "/auth";
+
+  public static class ContextInitializer
+      implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    @Override
+    public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+      TestPropertySourceUtils.addInlinedPropertiesToEnvironment(configurableApplicationContext,
+          "authServiceBaseUrl=" + mockWebServer.url(authMountPoint).toString());
+    }
+  }
+
+  @Value("${authServiceBaseUrl}")
+  String loadedBaseUrl;
+
+  @Test
+  void contextHasAuthValues() {
+    StringUtils.hasLength(loadedBaseUrl);
+    assertTrue("Context loads baseUrl", StringUtils.hasLength(loadedBaseUrl));
+  }
+
+  @Autowired
+  @Qualifier("AuthServiceWebClient")
+  WebClient underTest;
+
+  @Test
+  void authServiceWebClientSetsBaseUrlAndJwt() throws Exception {
+    String expected = "Success";
+    mockWebServer.enqueue(new MockResponse().setBody(expected));
+    assertEquals(expected,
+        underTest.get().uri("/path").retrieve().bodyToMono(String.class).block());
+
+    var req = mockWebServer.takeRequest();
+    assertEquals(authMountPoint + "/path", req.getPath());
+  }
+}

--- a/ochap-user-management/src/test/resources/application.properties
+++ b/ochap-user-management/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.main.lazy-initialization=true


### PR DESCRIPTION
This MR contains the following changes:

- Add web client for communicating with the external auth service.
  The webclient is automatically configured with the auth service URL.
  Such needs to be provided in the application context.
  This implementation includes integration tests that verify the external service
  behaves as the application expects.

- Add a 'service' component to interact with the external auth service.
  This service provides an abstraction over register and login.
  Its implementation simply delegates each operation using the web client.
  This service also provides a normalization layer for dealing with upstream
  validation errors, such as invalid credentials, unacceptable properties upon
  user creation and more.

- Have routes use the auth service for user registration and login.
  The user login and registration forms now provide inline feedback in the forms
  when a user provides unacceptable properties upon user creation or login.

- Configure wildfly to deploy the backend under `/` and he user management app under `/users/`.

- Add link to login and register to the backend.

I have tested all of these changes in the test infrastructure provisioned with vagrant.