### PR TITLE
Fix wildfly deployment again

### DIFF
--- a/ochap-backend/pom.xml
+++ b/ochap-backend/pom.xml
@@ -31,6 +31,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.tomcat.embed</groupId>
+					<artifactId>tomcat-embed-websocket</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/ochap-backend/pom.xml
+++ b/ochap-backend/pom.xml
@@ -40,6 +40,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-logging</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/ochap-backend/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/ochap-backend/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+  <deployment>
+    <dependencies>
+      <module name="ch.heigvd.amt.ochap_backend.configuration"/>
+    </dependencies>
+  </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
A very recurrent problem is that the repository cannot be deployed in wildfly because our tests do not run on the application server itself, but rather on the spring-test harness.

This is the third time I have to make a 'fix' MR just because deployment fails when we need to run on the application server.
Deploying in production to test whether it works and be surprised when the application server crashes is not acceptable.

This MR contains mere fixes to the current configuration, the whole issue should be addressed in a separate discussion.