### PR TITLE
infra: Fix bad variable name in testing playbook

### DIFF
--- a/infra/playbooks/group_vars/vagrant-testing.yml
+++ b/infra/playbooks/group_vars/vagrant-testing.yml
@@ -7,4 +7,4 @@ ansible_ssh_common_args: >-
 
 # There's no way to reach this service on a local deployment.
 ochap_usermgmt_auth_service_url: http://unexistent
-authServiceJwtSecret: invalid
+ochap_auth_service_jwt_secret: invalid


### PR DESCRIPTION
Fix little typo on default variables for the test inventory.

It did go unnoticed since I overriding this variable to use a forwarded connection to the auth server on amazon.