### PR TITLE
Move test files

### DIFF
--- a/ochap-backend/src/test/java/ch/heigvd/amt/backend/entities/ProductTest.java
+++ b/ochap-backend/src/test/java/ch/heigvd/amt/backend/entities/ProductTest.java
@@ -1,4 +1,4 @@
-package ch.heigvd.amt.backend;
+package ch.heigvd.amt.backend.entities;
 
 import ch.heigvd.amt.backend.entities.Category;
 import ch.heigvd.amt.backend.entities.Product;

--- a/ochap-backend/src/test/java/ch/heigvd/amt/backend/entities/ShoppingCartTest.java
+++ b/ochap-backend/src/test/java/ch/heigvd/amt/backend/entities/ShoppingCartTest.java
@@ -1,4 +1,4 @@
-package ch.heigvd.amt.backend;
+package ch.heigvd.amt.backend.entities;
 
 import ch.heigvd.amt.backend.entities.Category;
 import ch.heigvd.amt.backend.entities.Product;

--- a/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/LandingPageViewTests.java
+++ b/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/LandingPageViewTests.java
@@ -1,4 +1,4 @@
-package ch.heigvd.amt.backend;
+package ch.heigvd.amt.backend.routes;
 
 import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;


### PR DESCRIPTION
Moving the tests into directories will prevent naming clashes (such as the `Product` entity and `Product` route)