### PR TITLE
Admin authorization

### DIFF
--- a/ochap-backend/src/main/java/ch/heigvd/amt/backend/JwtFilter.java
+++ b/ochap-backend/src/main/java/ch/heigvd/amt/backend/JwtFilter.java
@@ -52,7 +52,7 @@ public class JwtFilter extends OncePerRequestFilter {
     String role = jwt.getClaim("role").asString();
 
     var auth = new PreAuthenticatedAuthenticationToken(subject, null,
-        Collections.singleton(new SimpleGrantedAuthority(role)));
+        Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role.toUpperCase())));
     auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
     SecurityContextHolder.getContext().setAuthentication(auth);
   }

--- a/ochap-backend/src/main/java/ch/heigvd/amt/backend/MvcConfig.java
+++ b/ochap-backend/src/main/java/ch/heigvd/amt/backend/MvcConfig.java
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableGlobalMethodSecurity(jsr250Enabled = true)
 public class MvcConfig implements WebMvcConfigurer {
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {

--- a/ochap-backend/src/main/java/ch/heigvd/amt/backend/MvcConfig.java
+++ b/ochap-backend/src/main/java/ch/heigvd/amt/backend/MvcConfig.java
@@ -4,10 +4,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class MvcConfig implements WebMvcConfigurer {
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {

--- a/ochap-backend/src/main/java/ch/heigvd/amt/backend/routes/CategoryManager.java
+++ b/ochap-backend/src/main/java/ch/heigvd/amt/backend/routes/CategoryManager.java
@@ -5,6 +5,7 @@ import ch.heigvd.amt.backend.entities.Product;
 import ch.heigvd.amt.backend.repository.CategoryDAO;
 import ch.heigvd.amt.backend.repository.ProductDAO;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 
 @Controller
+@PreAuthorize("hasAuthority('admin')")
 public class CategoryManager {
 
   @Autowired

--- a/ochap-backend/src/main/java/ch/heigvd/amt/backend/routes/CategoryManager.java
+++ b/ochap-backend/src/main/java/ch/heigvd/amt/backend/routes/CategoryManager.java
@@ -12,12 +12,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import javax.annotation.security.RolesAllowed;
 import javax.validation.Valid;
 import java.util.List;
 import java.util.Set;
 
 @Controller
-@PreAuthorize("hasAuthority('admin')")
+@RolesAllowed("ROLE_ADMIN")
 public class CategoryManager {
 
   @Autowired

--- a/ochap-backend/src/main/java/ch/heigvd/amt/backend/routes/ProductManager.java
+++ b/ochap-backend/src/main/java/ch/heigvd/amt/backend/routes/ProductManager.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.annotation.security.RolesAllowed;
 import javax.validation.Valid;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,7 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Controller
-@PreAuthorize("hasAuthority('admin')")
+@RolesAllowed("ROLE_ADMIN")
 public class ProductManager {
   @Autowired
   private ProductDAO productDAO;

--- a/ochap-backend/src/main/java/ch/heigvd/amt/backend/routes/ProductManager.java
+++ b/ochap-backend/src/main/java/ch/heigvd/amt/backend/routes/ProductManager.java
@@ -5,6 +5,7 @@ import ch.heigvd.amt.backend.entities.Product;
 import ch.heigvd.amt.backend.repository.CategoryDAO;
 import ch.heigvd.amt.backend.repository.ProductDAO;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.StringUtils;
@@ -27,6 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Controller
+@PreAuthorize("hasAuthority('admin')")
 public class ProductManager {
   @Autowired
   private ProductDAO productDAO;

--- a/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/CategoryManagerTest.java
+++ b/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/CategoryManagerTest.java
@@ -1,0 +1,38 @@
+package ch.heigvd.amt.backend.routes;
+
+import ch.heigvd.amt.backend.AmtBackendApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = AmtBackendApplication.class)
+@AutoConfigureMockMvc
+public class CategoryManagerTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    @Transactional
+    @WithMockUser(username = "test-user", authorities = "user")
+    public void nonAdminCantManageCategory() throws Exception{
+        this.mvc.perform(
+                get("/category-manager")
+        ).andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @Transactional
+    @WithMockUser(username = "test-user", authorities = "admin")
+    public void adminCanManageProduct() throws Exception{
+        this.mvc.perform(
+                get("/category-manager")
+        ).andExpect(status().is2xxSuccessful());
+    }
+}

--- a/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/CategoryManagerTest.java
+++ b/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/CategoryManagerTest.java
@@ -20,15 +20,15 @@ public class CategoryManagerTest {
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", authorities = "user")
+  @WithMockUser(username = "test-user", roles = "USER")
   public void nonAdminCantManageCategory() throws Exception {
     this.mvc.perform(get("/category-manager")).andExpect(status().is4xxClientError());
   }
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", authorities = "admin")
-  public void adminCanManageProduct() throws Exception {
+  @WithMockUser(username = "test-user", roles = "ADMIN")
+  public void adminCanManageCategory() throws Exception {
     this.mvc.perform(get("/category-manager")).andExpect(status().is2xxSuccessful());
   }
 }

--- a/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/CategoryManagerTest.java
+++ b/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/CategoryManagerTest.java
@@ -15,24 +15,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(classes = AmtBackendApplication.class)
 @AutoConfigureMockMvc
 public class CategoryManagerTest {
-    @Autowired
-    private MockMvc mvc;
+  @Autowired
+  private MockMvc mvc;
 
-    @Test
-    @Transactional
-    @WithMockUser(username = "test-user", authorities = "user")
-    public void nonAdminCantManageCategory() throws Exception{
-        this.mvc.perform(
-                get("/category-manager")
-        ).andExpect(status().is4xxClientError());
-    }
+  @Test
+  @Transactional
+  @WithMockUser(username = "test-user", authorities = "user")
+  public void nonAdminCantManageCategory() throws Exception {
+    this.mvc.perform(get("/category-manager")).andExpect(status().is4xxClientError());
+  }
 
-    @Test
-    @Transactional
-    @WithMockUser(username = "test-user", authorities = "admin")
-    public void adminCanManageProduct() throws Exception{
-        this.mvc.perform(
-                get("/category-manager")
-        ).andExpect(status().is2xxSuccessful());
-    }
+  @Test
+  @Transactional
+  @WithMockUser(username = "test-user", authorities = "admin")
+  public void adminCanManageProduct() throws Exception {
+    this.mvc.perform(get("/category-manager")).andExpect(status().is2xxSuccessful());
+  }
 }

--- a/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/ProductManagerTests.java
+++ b/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/ProductManagerTests.java
@@ -27,21 +27,21 @@ public class ProductManagerTests {
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", authorities = "user")
+  @WithMockUser(username = "test-user", roles = "USER")
   public void nonAdminCantManageProduct() throws Exception {
     this.mvc.perform(get("/product-manager")).andExpect(status().is4xxClientError());
   }
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", authorities = "admin")
+  @WithMockUser(username = "test-user", roles = "ADMIN")
   public void adminCanManageProduct() throws Exception {
     this.mvc.perform(get("/product-manager")).andExpect(status().is2xxSuccessful());
   }
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", authorities = "admin")
+  @WithMockUser(username = "test-user", roles = "ADMIN")
   public void createNewProduct() throws Exception {
     String name = "test product " + UUID.randomUUID().toString();
     String description = "Description for test product";
@@ -55,7 +55,7 @@ public class ProductManagerTests {
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", authorities = "admin")
+  @WithMockUser(username = "test-user", roles = "ADMIN")
   public void createDuplicateProduct() throws Exception {
     String name = "test product " + UUID.randomUUID().toString();
     String description = "Description for test product";
@@ -74,7 +74,7 @@ public class ProductManagerTests {
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", authorities = "admin")
+  @WithMockUser(username = "test-user", roles = "ADMIN")
   public void updateProduct() throws Exception {
     String name = "test product " + UUID.randomUUID().toString();
     String description = "Description for test product";

--- a/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/ProductManagerTests.java
+++ b/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/ProductManagerTests.java
@@ -28,19 +28,15 @@ public class ProductManagerTests {
   @Test
   @Transactional
   @WithMockUser(username = "test-user", authorities = "user")
-  public void nonAdminCantManageProduct() throws Exception{
-      this.mvc.perform(
-              get("/product-manager")
-      ).andExpect(status().is4xxClientError());
+  public void nonAdminCantManageProduct() throws Exception {
+    this.mvc.perform(get("/product-manager")).andExpect(status().is4xxClientError());
   }
 
   @Test
   @Transactional
   @WithMockUser(username = "test-user", authorities = "admin")
-  public void adminCanManageProduct() throws Exception{
-    this.mvc.perform(
-            get("/product-manager")
-    ).andExpect(status().is2xxSuccessful());
+  public void adminCanManageProduct() throws Exception {
+    this.mvc.perform(get("/product-manager")).andExpect(status().is2xxSuccessful());
   }
 
   @Test

--- a/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/ProductManagerTests.java
+++ b/ochap-backend/src/test/java/ch/heigvd/amt/backend/routes/ProductManagerTests.java
@@ -27,7 +27,25 @@ public class ProductManagerTests {
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", roles = "admin")
+  @WithMockUser(username = "test-user", authorities = "user")
+  public void nonAdminCantManageProduct() throws Exception{
+      this.mvc.perform(
+              get("/product-manager")
+      ).andExpect(status().is4xxClientError());
+  }
+
+  @Test
+  @Transactional
+  @WithMockUser(username = "test-user", authorities = "admin")
+  public void adminCanManageProduct() throws Exception{
+    this.mvc.perform(
+            get("/product-manager")
+    ).andExpect(status().is2xxSuccessful());
+  }
+
+  @Test
+  @Transactional
+  @WithMockUser(username = "test-user", authorities = "admin")
   public void createNewProduct() throws Exception {
     String name = "test product " + UUID.randomUUID().toString();
     String description = "Description for test product";
@@ -41,7 +59,7 @@ public class ProductManagerTests {
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", roles = "admin")
+  @WithMockUser(username = "test-user", authorities = "admin")
   public void createDuplicateProduct() throws Exception {
     String name = "test product " + UUID.randomUUID().toString();
     String description = "Description for test product";
@@ -60,7 +78,7 @@ public class ProductManagerTests {
 
   @Test
   @Transactional
-  @WithMockUser(username = "test-user", roles = "admin")
+  @WithMockUser(username = "test-user", authorities = "admin")
   public void updateProduct() throws Exception {
     String name = "test product " + UUID.randomUUID().toString();
     String description = "Description for test product";


### PR DESCRIPTION
This PR enable and use security annotations to authorize access to the management of products and categories only if the user has the **admin** authority.

PSA: For all further authorization stuff, use the **authority** spring mechanism instead of the **role** one

Closes #66 